### PR TITLE
fix: utils: get_platform() on macos

### DIFF
--- a/lua/dap-cortex-debug/utils.lua
+++ b/lua/dap-cortex-debug/utils.lua
@@ -111,7 +111,7 @@ end
 ---Determine system platform
 ---@return 'darwin'|'windows'|'linux'
 function M.get_platform()
-    if vim.fn.has('macos') == 1 then
+    if vim.fn.has('macos') == 1 or vim.fn.has('osx') == 1 then
         return 'darwin'
     elseif vim.fn.has('win32') == 1 or vim.fn.has('win64') == 1 then
         return 'windows'


### PR DESCRIPTION
Fixed vim.fn.has('macos') returns 0 on macos Sonoma, added vim.fn.has('osx') check which returns 1 as intended.

Detected using JLink Zephyr RTOS plugin, which had .so extension added in adapter.lua due to wrong os detection and thus was not found.