### PR TITLE
Improve JLinkRTT connection

### DIFF
--- a/lua/dap-cortex-debug/consoles.lua
+++ b/lua/dap-cortex-debug/consoles.lua
@@ -176,8 +176,9 @@ function M.rtt_connect(opts, on_connected, on_client_connected)
     tcp.connect {
         host = '0.0.0.0',
         port = opts.tcp_port,
-        retries = 20,
-        delay = 250,
+        delay = 10,
+        delay_multiplier = 2,
+        delay_total_max = 5000,
         on_error = vim.schedule_wrap(function(err)
             utils.error('Failed to connect RTT:%d on TCP port %d: %s', opts.channel, opts.tcp_port, err)
         end),


### PR DESCRIPTION
Current implementation had a considerable delay between connecting to JLink RTT Telnet channel which often exceeded the 100 ms limit (https://wiki.segger.com/J-Link_RTT_TELNET_Channel). This was due to the fact that the callback was `vim.schedule`d. Now the config string is sent directly in the callback so there should be no problems.

As a bonus, `tcp.connect` now supports adaptive retry delay and we use x2 multiplier for RTT, starting from 10 ms with a total limit of 5 seconds before timeout.