### PR TITLE
fix: Make certain verifier functions return config

### DIFF
--- a/lua/dap-cortex-debug/adapter.lua
+++ b/lua/dap-cortex-debug/adapter.lua
@@ -93,11 +93,13 @@ end
 function verifiers.stutil(c)
     no_rtos(c, 'ST-Util')
     no_swo(c, 'ST-Util')
+    return c
 end
 
 function verifiers.stlink(c)
     no_rtos(c, 'ST-Link')
     no_swo(c, 'ST-Link')
+    return c
 end
 
 function verifiers.pyocd(c)
@@ -118,6 +120,7 @@ function verifiers.bmp(c)
     c.targetId = c.targetId or 1
     no_rtos(c, 'Black Magic Probe')
     no_swo(c, 'Black Magic Probe')
+    return c
 end
 
 function verifiers.pe(c)
@@ -130,6 +133,8 @@ function verifiers.pe(c)
         not (c.swoConfig and c.swoConfig.enabled and c.swoConfig.source ~= 'socket'),
         'The PE GDB Server Only supports socket type SWO'
     )
+
+    return c
 end
 
 function verifiers.external(c)
@@ -148,6 +153,8 @@ function verifiers.external(c)
         c.gdbTarget,
         'External GDB server type must specify the GDB target. This should either be a "hostname:port" combination or a serial port.'
     )
+
+    return c
 end
 
 function verifiers.qemu(c)


### PR DESCRIPTION
Noticed when attempting to use the `external` servertype. This is required since [this line](https://github.com/jedrzejboczar/nvim-dap-cortex-debug/blob/master/lua/dap-cortex-debug/adapter.lua#L238) expects the verifiers to return a potentially modified config.