### PR TITLE
FIX 'yield accross C boundary' error when using RTT console

### DIFF
--- a/lua/dap-cortex-debug/listeners.lua
+++ b/lua/dap-cortex-debug/listeners.lua
@@ -85,7 +85,9 @@ function M.setup()
             -- Notify our dapui element to update
             require('dap-cortex-debug.dapui.rtt').on_rtt_connect(channel)
 
-            session:request('rtt-poll')
+            session:request('rtt-poll', nil, function(_, _)
+            end)
+
             term:scroll()
         end, on_client_connected)
     end)


### PR DESCRIPTION
Add empty on_result function parameter in rtt-poll request

In dap.nvim, when on_result is nil, behaviour is to add a coroutine and on_result that resume it. In this case, it yields just after call, that was causing 'yield accross C boundary error'. Fixed with an empty on_result function on call session:request('rtt-poll').

Tested with a Zephyr project using RTT console, working properly